### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*           text=auto
+*.fa        text eol=lf


### PR DESCRIPTION
To pass the faidex test on Windows, force the newline code to LF so that the offset is not shifted.